### PR TITLE
feat(frontend): protect all dashboard routes via layout

### DIFF
--- a/frontend/src/app/dashboard/coaches/page.tsx
+++ b/frontend/src/app/dashboard/coaches/page.tsx
@@ -23,12 +23,8 @@ interface Coach {
   statut: 'coach' | 'admin';
 }
 
-const CoachesPage = () => {
-  return (
-    <ProtectedRoute>
-      <CoachesContent />
-    </ProtectedRoute>
-  )
+export default function CoachesPage() {
+  return <CoachesContent />
 }
 
 const CoachesContent = () => {
@@ -467,4 +463,3 @@ const [isDeleting, setIsDeleting] = useState(false);
 }
 
 
-export default CoachesPage;

--- a/frontend/src/app/dashboard/layout.tsx
+++ b/frontend/src/app/dashboard/layout.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import { ProtectedRoute } from '@/components/auth/ProtectedRoute'
+
+export default function DashboardLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <ProtectedRoute>
+      {children}
+    </ProtectedRoute>
+  )
+}

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -2,13 +2,8 @@
 'use client'
 
 import { Dashboard } from "@/components/Dashboard";
-import { ProtectedRoute } from "@/components/auth/ProtectedRoute";
 
 
 export default function DashboardPage() {
-  return (
-    <ProtectedRoute>
-      <Dashboard />
-    </ProtectedRoute>
-  )
+  return <Dashboard /> 
 }


### PR DESCRIPTION
## Summary
- Add `dashboard/layout.tsx` wrapping all `/dashboard/*` routes with `ProtectedRoute`
- Remove duplicate `ProtectedRoute` wrappers from `dashboard/page.tsx` and `dashboard/coaches/page.tsx`
- Ensure unauthenticated users are redirected to `/login` for students, planning, import, admin, and attendance pages

## Test plan
- [ ] While logged out, visit `/dashboard/students` → redirects to `/login`
- [ ] While logged out, visit `/dashboard/planning`, `/dashboard/import`, `/dashboard/admin`, `/dashboard/attendance` → same redirect
- [ ] While logged in, all dashboard pages load normally
- [ ] `/dashboard` and `/dashboard/coaches` still work as before
- [ ] `npm run lint` passes in `frontend/`