### PR TITLE
feat(frontend): show dashboard sidebar on all dashboard routes

### DIFF
--- a/frontend/src/app/dashboard/attendance/page.tsx
+++ b/frontend/src/app/dashboard/attendance/page.tsx
@@ -1,9 +1,7 @@
 'use client'
 import { useState, useEffect, Suspense } from 'react'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
-import { Button } from '@/components/ui/button'
-import { Home, Loader2 } from 'lucide-react'
-import Link from 'next/link'
+import { Loader2 } from 'lucide-react'
 import { CourseCard } from '@/components/attendance/CourseCard'
 import { useSearchParams } from 'next/navigation'
 import { useSubscriptions } from '@/lib/hooks/useSubscriptions'
@@ -458,12 +456,7 @@ function AttendancePageContent() {
           </h1>
         <p className="text-gray-600">Gérez les présences des élèves par cours</p>
         </div>
-        <Link href="/dashboard">
-          <Button variant="outline" className="flex items-center gap-2 w-full md:w-auto">
-            <Home className="h-4 w-4" />
-            Retour au Dashboard
-          </Button>
-        </Link>
+        
       </div>
 
       <Tabs value={selectedDay} onValueChange={setSelectedDay} className="w-full">

--- a/frontend/src/app/dashboard/coaches/page.tsx
+++ b/frontend/src/app/dashboard/coaches/page.tsx
@@ -10,7 +10,6 @@ import { SelectNative } from '@/components/ui/select-native';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog';
 import { Edit, Save, X, Home, Loader2, Plus } from 'lucide-react';
 import { useState } from 'react';
-import Link from 'next/link';
 import { api } from '@/lib/api/api';
 
 interface Coach {
@@ -162,12 +161,7 @@ const [isDeleting, setIsDeleting] = useState(false);
         Ajouter un coach
       </Button>
     )}
-    <Link href="/dashboard">
-      <Button variant="outline" className="flex items-center gap-2 w-full md:w-auto">
-        <Home className="h-4 w-4" />
-        Retour au Dashboard
-      </Button>
-    </Link>
+    
   </div>
 </div>
 

--- a/frontend/src/app/dashboard/import/page.tsx
+++ b/frontend/src/app/dashboard/import/page.tsx
@@ -1,18 +1,11 @@
 import { CsvUploader } from '@/components/CsvUploader';
-import Link from 'next/link';
-import { ArrowLeft } from 'lucide-react';
-import { Button } from '@/components/ui/button';
+
 
 export default function ImportPage() {
   return (
     <div className="container mx-auto p-4">
       <div className="flex flex-col gap-4 mb-6">
-        <Link href="/dashboard">
-          <Button variant="outline" size="sm" className="flex items-center gap-2">
-            <ArrowLeft className="w-4 h-4" />
-            Retour au dashboard
-          </Button>
-        </Link>
+        
       </div>
       <div className="max-w-xl mx-auto mb-6">
         <h1 className="text-2xl font-bold text-center">Import de données</h1>

--- a/frontend/src/app/dashboard/layout.tsx
+++ b/frontend/src/app/dashboard/layout.tsx
@@ -1,15 +1,34 @@
 'use client'
 
+import { AppSidebar } from '@/components/AppSidebar'
 import { ProtectedRoute } from '@/components/auth/ProtectedRoute'
+import { SidebarInset } from '@/components/ui/sidebar'
+import { SidebarProvider, SidebarTrigger } from '@/components/ui/sidebar'
+import { useAuth } from '@/lib/auth/AuthContext'
+export default function DashboardLayout({ children }: { children: React.ReactNode }) {
+  const { user, userProfile, userRole } = useAuth()
 
-export default function DashboardLayout({
-  children,
-}: {
-  children: React.ReactNode
-}) {
   return (
     <ProtectedRoute>
-      {children}
+      <SidebarProvider>
+        <AppSidebar />
+        <SidebarInset>
+        <header className="flex h-16 items-center gap-2 border-b px-4">
+  <SidebarTrigger className="-ml-1" />
+  <div className="text-sm text-gray-500">
+    Bonjour {userProfile?.prenom || user?.email || 'Utilisateur'}
+    {userRole && (
+      <span className="ml-2 text-xs bg-blue-100 text-blue-800 px-2 py-1 rounded">
+        {userRole}
+      </span>
+    )}
+  </div>
+</header>
+          <main className="p-4">
+            {children}   {/* ← pas StatsDashboard ici */}
+          </main>
+        </SidebarInset>
+      </SidebarProvider>
     </ProtectedRoute>
   )
 }

--- a/frontend/src/app/dashboard/students/__tests__/page.test.tsx
+++ b/frontend/src/app/dashboard/students/__tests__/page.test.tsx
@@ -93,12 +93,13 @@ describe('StudentsPage', () => {
     expect(screen.getByText('Chargement des élèves...')).toBeInTheDocument()
   })
 
-  it('should render back to dashboard button', async () => {
+  it('should render the students page title', async () => {
     mockLoadedStudents()
     render(<StudentsPage />)
 
     await waitFor(() => {
-      expect(screen.getByText('Retour au Dashboard')).toBeInTheDocument()
+      // Navigation vers le dashboard se fait via la sidebar, plus de bouton "Retour"
+      expect(screen.getByText('Liste des élèves par cours')).toBeInTheDocument()
     })
   })
 

--- a/frontend/src/app/dashboard/students/page.tsx
+++ b/frontend/src/app/dashboard/students/page.tsx
@@ -12,7 +12,6 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Pencil, Trash2, Home, Phone, MapPin, CreditCard, FileText } from "lucide-react";
-import Link from "next/link";
 import { useSubscriptions, useUniqueTarifs, type Subscription } from '@/lib/hooks/useSubscriptions';
 import { api } from '@/lib/api/api';
 
@@ -341,12 +340,7 @@ const StudentsPage = () => {
         <h1 className="text-2xl md:text-3xl font-bold">
           Liste des élèves par cours
         </h1>
-        <Link href="/dashboard">
-          <Button variant="outline" className="flex items-center gap-2 w-full md:w-auto">
-            <Home className="h-4 w-4" />
-            Retour au Dashboard
-          </Button>
-        </Link>
+
       </div>
       
       <div className="mb-6">

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -2,8 +2,6 @@
 
 import dynamic from 'next/dynamic'
 import { useAuth } from '@/lib/auth/AuthContext'
-import { SidebarProvider, SidebarTrigger, SidebarInset } from '@/components/ui/sidebar'
-import { AppSidebar } from '@/components/AppSidebar'
 import CoachesList from '@/components/CoachesList'
 
 const StatsDashboard = dynamic(
@@ -42,34 +40,17 @@ export function Dashboard() {
   }
 
   return (
-    <SidebarProvider>
-      <AppSidebar />
-      <SidebarInset>
-        <header className="flex h-16 items-center gap-2 border-b px-4">
-          <SidebarTrigger className="-ml-1" />
-          <div className="text-sm text-gray-500">
-            Bonjour {userProfile?.prenom || user?.email || 'Utilisateur'}
-            {userRole && <span className="ml-2 text-xs bg-blue-100 text-blue-800 px-2 py-1 rounded">{userRole}</span>}
-          </div>
-        </header>
-        
-        <main className="p-4">
-          {userProfile?.prenom ? (
-            <>
-              {/* Charger seulement les données essentielles du dashboard */}
-              <StatsDashboard />
-              <CoachesList />
-            </>
-          ) : (
-            <div className="flex items-center justify-center py-12">
-              <div className="flex flex-col items-center gap-4">
-                <Loader2 className="h-8 w-8 animate-spin text-blue-600" />
-                <p className="text-gray-600">Chargement de vos données...</p>
-              </div>
-            </div>
-          )}
-        </main>
-      </SidebarInset>
-    </SidebarProvider>
+    <>
+      {userProfile?.prenom ? (
+        <>
+          <StatsDashboard />
+          <CoachesList />
+        </>
+      ) : (
+        <div className="flex items-center justify-center py-12">
+          …
+        </div>
+      )}
+    </>
   )
 }

--- a/frontend/src/components/LazyNavigation.tsx
+++ b/frontend/src/components/LazyNavigation.tsx
@@ -2,7 +2,6 @@
 
 import { useRouter } from 'next/navigation'
 import { useQueryClient } from '@tanstack/react-query'
-import { pageCache } from '@/lib/cache/pageCache'
 
 interface LazyNavigationProps {
   href: string

--- a/frontend/src/test-utils/setupDashboardTests.ts
+++ b/frontend/src/test-utils/setupDashboardTests.ts
@@ -12,7 +12,7 @@ jest.mock('@/lib/auth/AuthContext', () => ({
 }))
 
 export const mockUseSubscriptions = jest.fn(() => ({
-  data: [],
+  data: []as unknown[],
   isLoading: true,
   error: null,
   refetch: jest.fn(),


### PR DESCRIPTION
Move SidebarProvider/AppSidebar into the dashboard layout so navigation persists across pages, and remove redundant back-to-dashboard buttons.